### PR TITLE
nixpkgs: bump to nixos/nixpkgs-channels#ef026e02f

### DIFF
--- a/nix/nixpkgs/config.nix
+++ b/nix/nixpkgs/config.nix
@@ -88,11 +88,14 @@
         # reason.
         # hakyll = dontCheck super.hakyll;
 
-        # Need a version bump on HUnit.
-        # snap = self.callPackage ~/src/snap {};
+        snap = self.callPackage ~/src/snap {};
 
         # Need a version bump on directory.
         snap-loader-dynamic = self.callPackage ~/src/snap-loader-dynamic {};
+
+        # Need a version bump.
+        xmlhtml = self.callPackage ~/src/xmlhtml {};
+        heist = self.callPackage ~/src/heist {};
       };
     };
 
@@ -197,7 +200,7 @@
       transformers
       turtle
       unordered-containers
-      uuid-aeson
+      uuid
       vector
       wreq
     ]);

--- a/nix/nixpkgs/config.nix
+++ b/nix/nixpkgs/config.nix
@@ -88,14 +88,12 @@
         # reason.
         # hakyll = dontCheck super.hakyll;
 
-        snap = self.callPackage ~/src/snap {};
-
-        # Need a version bump on directory.
-        snap-loader-dynamic = self.callPackage ~/src/snap-loader-dynamic {};
-
-        # Need a version bump.
-        xmlhtml = self.callPackage ~/src/xmlhtml {};
-        heist = self.callPackage ~/src/heist {};
+        # Point at current master, where dependency issues have been
+        # fixed.
+        snap-loader-dynamic = self.callPackage ~/.dotfiles/nix/pkgs/snap-loader-dynamic { };
+        snap = self.callPackage ~/.dotfiles/nix/pkgs/snap {};
+        xmlhtml = self.callPackage ~/.dotfiles/nix/pkgs/xmlhtml {};
+        heist = self.callPackage ~/.dotfiles/nix/pkgs/heist {};
       };
     };
 

--- a/nix/pkgs/heist/default.nix
+++ b/nix/pkgs/heist/default.nix
@@ -1,0 +1,44 @@
+{ mkDerivation, aeson, attoparsec, base, bifunctors, blaze-builder
+, blaze-html, bytestring, containers, criterion, directory
+, directory-tree, dlist, filepath, hashable, HUnit, lens
+, lifted-base, map-syntax, monad-control, mtl, process, QuickCheck
+, random, statistics, stdenv, test-framework, test-framework-hunit
+, test-framework-quickcheck2, text, time, transformers
+, transformers-base, unordered-containers, vector, xmlhtml
+, pandoc
+, fetchgit
+}:
+mkDerivation {
+  pname = "heist";
+  version = "1.0.1.0";
+  src = fetchgit {
+    url = "https://github.com/snapframework/heist.git";
+    rev = "7731eb14a1537a69a24358b1b700362271bc88e6";
+    sha256 = "15a7j7q4v5mba8a9v6x8rlvyhpcq62953b12syq9hc6aq28gkqyg";
+    fetchSubmodules = false;
+  };
+  libraryHaskellDepends = [
+    aeson attoparsec base blaze-builder blaze-html bytestring
+    containers directory directory-tree dlist filepath hashable
+    lifted-base map-syntax monad-control mtl process random text time
+    transformers transformers-base unordered-containers vector xmlhtml
+  ];
+  testHaskellDepends = [
+    aeson attoparsec base bifunctors blaze-builder blaze-html
+    bytestring containers directory directory-tree dlist filepath
+    hashable HUnit lens lifted-base map-syntax monad-control mtl
+    process QuickCheck random test-framework test-framework-hunit
+    test-framework-quickcheck2 text time transformers transformers-base
+    unordered-containers vector xmlhtml pandoc
+  ];
+  benchmarkHaskellDepends = [
+    aeson attoparsec base blaze-builder blaze-html bytestring
+    containers criterion directory directory-tree dlist filepath
+    hashable HUnit lifted-base map-syntax monad-control mtl process
+    random statistics test-framework test-framework-hunit text time
+    transformers transformers-base unordered-containers vector xmlhtml
+  ];
+  homepage = "http://snapframework.com/";
+  description = "An Haskell template system supporting both HTML5 and XML";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/pkgs/snap-loader-dynamic/default.nix
+++ b/nix/pkgs/snap-loader-dynamic/default.nix
@@ -1,0 +1,20 @@
+{ mkDerivation, base, directory, directory-tree, hint, mtl
+, snap-core, stdenv, template-haskell, time, unix
+, fetchgit
+}:
+mkDerivation {
+  pname = "snap-loader-dynamic";
+  version = "1.0.0.0";
+  src = fetchgit {
+    url = "https://github.com/snapframework/snap-loader-dynamic.git";
+    rev = "b4fae0f3356a09e83852a530c44d2caf6c3e0442";
+    sha256 = "1h0hpb8zssh39jb03drr921b5xiqjamga8w4fyq1l2v9r292bgiw";
+  };
+  libraryHaskellDepends = [
+    base directory directory-tree hint mtl snap-core template-haskell
+    time unix
+  ];
+  homepage = "http://snapframework.com/";
+  description = "Snap dynamic loader";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/pkgs/snap/default.nix
+++ b/nix/pkgs/snap/default.nix
@@ -1,0 +1,41 @@
+{ mkDerivation, aeson, async, attoparsec, base, bytestring, cereal
+, clientsession, configurator, containers, deepseq, directory
+, directory-tree, dlist, filepath, Glob, hashable, heist
+, http-streams, HUnit, lens, lifted-base, map-syntax, monad-control
+, mtl, mwc-random, pwstore-fast, QuickCheck, smallcheck, snap-core
+, snap-server, stdenv, stm, syb, test-framework
+, test-framework-hunit, test-framework-quickcheck2
+, test-framework-smallcheck, text, time, transformers
+, transformers-base, unordered-containers, xmlhtml
+, fetchgit
+}:
+mkDerivation {
+  pname = "snap";
+  version = "1.0.0.1";
+  src = fetchgit {
+    rev = "b890d957d02c6fa8405c62b1e9632acf3235e3bb";
+    sha256 = "11sb5z9i4y90075v1gsx7980r58x5kn4g1zrrbwnkd23hzziwa7z";
+    url = "https://github.com/snapframework/snap.git";
+    fetchSubmodules = false;
+  };
+  libraryHaskellDepends = [
+    aeson attoparsec base bytestring cereal clientsession configurator
+    containers directory directory-tree dlist filepath hashable heist
+    lens lifted-base map-syntax monad-control mtl mwc-random
+    pwstore-fast snap-core snap-server stm text time transformers
+    transformers-base unordered-containers xmlhtml
+  ];
+  testHaskellDepends = [
+    aeson async attoparsec base bytestring cereal clientsession
+    configurator containers deepseq directory directory-tree dlist
+    filepath Glob hashable heist http-streams HUnit lens lifted-base
+    map-syntax monad-control mtl mwc-random pwstore-fast QuickCheck
+    smallcheck snap-core snap-server stm syb test-framework
+    test-framework-hunit test-framework-quickcheck2
+    test-framework-smallcheck text time transformers transformers-base
+    unordered-containers xmlhtml
+  ];
+  homepage = "http://snapframework.com/";
+  description = "Top-level package for the Snap Web Framework";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/pkgs/xmlhtml/default.nix
+++ b/nix/pkgs/xmlhtml/default.nix
@@ -1,0 +1,28 @@
+{ mkDerivation, base, blaze-builder, blaze-html, blaze-markup
+, bytestring, bytestring-builder, containers, directory, HUnit
+, parsec, stdenv, test-framework, test-framework-hunit, text
+, unordered-containers, hspec
+, fetchgit
+}:
+mkDerivation {
+  pname = "xmlhtml";
+  version = "0.2.5";
+  src = fetchgit {
+    url = "https://github.com/snapframework/xmlhtml.git";
+    rev = "67e030ca113d29b0b09b84a353d3b456ad457179";
+    sha256 = "1l15xw12qc53q5vllds93qj22268zyf8shvn7ia9fwxwgiwjdfq8";
+    fetchSubmodules = false;
+  };
+  libraryHaskellDepends = [
+    base blaze-builder blaze-html blaze-markup bytestring
+    bytestring-builder containers parsec text unordered-containers
+  ];
+  testHaskellDepends = [
+    base blaze-builder blaze-html blaze-markup bytestring
+    bytestring-builder directory HUnit test-framework
+    test-framework-hunit text hspec
+  ];
+  homepage = "https://github.com/snapframework/xmlhtml";
+  description = "XML parser and renderer with HTML 5 quirks mode";
+  license = stdenv.lib.licenses.bsd3;
+}


### PR DESCRIPTION
- remove uuid-aeson in favor of new aeson that comes with uuid
  instances

- fork & fix heist, xmlhtml, snap for dependency bumps