### PR TITLE
emacs: fix missing org-mime

### DIFF
--- a/emacs.d/lisp/init-org.el
+++ b/emacs.d/lisp/init-org.el
@@ -1,6 +1,7 @@
 (require 'init-basic)
 
 (mjhoy/require-package 'org-plus-contrib)
+(mjhoy/require-package 'org-mime)
 
 (require 'org)
 (require 'org-mime)


### PR DESCRIPTION
fixes #11

See http://orgmode.org/Changes.html -- org-mode 9.1 dropped org-mime
from the repository.