### PR TITLE
nix: enable protobuf-mode emacs package

### DIFF
--- a/nix/nixpkgs/config.nix
+++ b/nix/nixpkgs/config.nix
@@ -204,7 +204,7 @@
           posframe
           projectile
           proof-general
-          # protobuf-mode # https://github.com/nix-community/emacs-overlay/issues/26
+          protobuf-mode
           racer
           rjsx-mode
           robe


### PR DESCRIPTION
This appears to be fixed now.