### PR TITLE
nix: bump, switch to 21.11 branch

### DIFF
--- a/nix/nixpkgs/config.nix
+++ b/nix/nixpkgs/config.nix
@@ -85,6 +85,7 @@
           ace-window
           cl-lib
           rainbow-mode
+          org
         ]) ++ (with epkgs.melpaStablePackages; [
           ag
           apache-mode
@@ -120,7 +121,6 @@
           php-mode
           posframe
           projectile
-          proof-general
           protobuf-mode
           racer
           rjsx-mode
@@ -137,8 +137,8 @@
           yaml-mode
           yard-mode
           yasnippet
-        ]) ++ (with epkgs.orgPackages; [
-          org-plus-contrib
+        ]) ++ (with epkgs.nongnuPackages; [
+          org-contrib
         ]) ++ (with epkgs.melpaPackages; [
           company-racer
           flycheck-rust
@@ -149,6 +149,7 @@
           lsp-sourcekit
           magit
           ox-reveal
+          proof-general
           psc-ide
           purescript-mode
           restclient

--- a/scripts/bump-nixpkgs
+++ b/scripts/bump-nixpkgs
@@ -7,7 +7,7 @@
 LOCAL_REMOTE=mjhoy
 LOCAL_BRANCH=mjh-mbp
 UPDATE_REMOTE=origin
-UPDATE_BRANCH=nixpkgs-21.05-darwin
+UPDATE_BRANCH=nixpkgs-21.11-darwin
 
 set -eoux pipefail
 


### PR DESCRIPTION
This required a couple of tweaks for emacs packages, moving them
around to different repositories.