### PR TITLE
nix: add aspell to devEnv

### DIFF
--- a/nix/nixpkgs/config.nix
+++ b/nix/nixpkgs/config.nix
@@ -23,7 +23,6 @@
         clang
 
         # other
-        aspellEnv
         bmon
         coreutils
         docker_compose
@@ -178,6 +177,7 @@
 
         # useful tools
         ag
+        aspellEnv
         cloc
         cmake
         ctags


### PR DESCRIPTION
I believe this was the original issue for which I left it out of my `devEnv`: https://github.com/nixos/nixpkgs/issues/1000