### PR TITLE
emacs: org: fix shortcuts

### DIFF
--- a/emacs.d/lisp/init-org/shortcuts.el
+++ b/emacs.d/lisp/init-org/shortcuts.el
@@ -1,12 +1,12 @@
-(defun mjhoy/open-org-notebook (filename &optional use-helm)
-  (let ((find-func #'counsel-find-file))
+(defun mjhoy/open-org-notebook (filename &optional use-completion)
+  (let ((find-func (if use-completion #'counsel-find-file #'find-file)))
     (funcall find-func (concat org-directory filename))))
 
 (defmacro openo (&rest forms)
   `(fni (mjhoy/open-org-notebook ,@forms)))
 
-(global-set-key (kbd "C-c o o") (lambda () (interactive) (find-file (concat org-directory "organizer.org"))))
-(global-set-key (kbd "C-c o a") (openo "organizer_archive.org"))
+(global-set-key (kbd "C-c o o") (openo "organizer.org"))
+(global-set-key (kbd "C-c o a") (openo "archive" t))
 (global-set-key (kbd "C-c o p") (openo "programming_notes/" t))
 (global-set-key (kbd "C-c o r") (openo "reading_notes.org"))
 (global-set-key (kbd "C-c o b") (openo "belch.org"))
@@ -14,9 +14,7 @@
 (global-set-key (kbd "C-c o j") (openo "projects.org"))
 (global-set-key (kbd "C-c o f") (openo "finance.org"))
 (global-set-key (kbd "C-c o w") (openo "work/" t))
-
-(global-set-key (kbd "C-c o ?") (fni (let ((default-directory org-directory))
-                                       (helm-find-files nil))))
+(global-set-key (kbd "C-c o ?") (openo "" t))
 
 (global-set-key (kbd "C-c o c") (fni (org-clock-jump-to-current-clock)))
 (global-set-key (kbd "C-c o C") 'org-contacts)


### PR DESCRIPTION
This still had references to `helm`, which I no longer use.