### PR TITLE
emacs: don't gitignore custom.el

### DIFF
--- a/emacs.d/.gitignore
+++ b/emacs.d/.gitignore
@@ -10,7 +10,6 @@ bookmarks
 smex-items
 emacs.el
 network-security.data
-custom.el
 .mc-lists.el
 transient
 .lsp-session*


### PR DESCRIPTION
variables I edit using the Customize interface go in here; I want this
to be noisy so I remember to move those customizations eventually into
my init files.