### PR TITLE
emacs: haskell: better lsp settings

### DIFF
--- a/emacs.d/lisp/init-haskell.el
+++ b/emacs.d/lisp/init-haskell.el
@@ -1,4 +1,5 @@
 (require 'haskell-mode)
+(require 'init-lsp)
 
 (defun mjhoy/setup-haskell-mode ()
   "My setup for haskell-mode."
@@ -7,6 +8,9 @@
   )
 
 (add-hook 'haskell-mode-hook #'mjhoy/setup-haskell-mode)
+
+(setq lsp-haskell-plugin-import-lens-code-lens-on nil)
+(setq lsp-haskell-formatting-provider "brittany")
 
 (defun mjhoy/format-haskell-on-save ()
   "Function to format a haskell buffer with brittany on save."


### PR DESCRIPTION
- Turn off the `importLens` plugin, which adds a ton of hints to my
  imports in the editor and looks bad.
- Set the formatting provider to `brittany`.