### PR TITLE
emacs: macos: explicit modifier settings

### DIFF
--- a/emacs.d/lisp/init-misc.el
+++ b/emacs.d/lisp/init-misc.el
@@ -21,6 +21,12 @@
 
       ;; Darwin's ls does not support the --dired option.
       (setq dired-use-ls-dired nil)
+
+      ;; Option key is meta
+      (setq ns-alternate-modifier 'meta)
+
+      ;; Command key is super
+      (setq ns-command-modifier 'super)
       ))
 
 ;; Macport specific stuff


### PR DESCRIPTION
I don't think this actually changes anything, but these were living in
my custom.el, moving them to the init file.