### PR TITLE
add rust-analyzer bin script

### DIFF
--- a/bin/rust-analyzer
+++ b/bin/rust-analyzer
@@ -1,0 +1,5 @@
+#!/bin/bash
+#
+# https://github.com/rust-lang/rustup/issues/2411
+set -euo pipefail
+exec rustup run "$(rustup show active-toolchain | cut -d' ' -f1)" rust-analyzer "$@"


### PR DESCRIPTION
For some reason, `rust-analyzer` isn't added to ~/.cargo/bin;
https://github.com/rust-lang/rustup/issues/2411 has some context.