### PR TITLE
emacs: multiple-cursors: global key for mark-next-like-this-symbol

### DIFF
--- a/emacs.d/lisp/init-multiple-cursors.el
+++ b/emacs.d/lisp/init-multiple-cursors.el
@@ -1,5 +1,6 @@
 (require 'multiple-cursors)
 
 (global-set-key (kbd "C-S-c C-S-c") 'mc/edit-lines)
+(global-set-key (kbd "C-S-c C-S-n") 'mc/mark-next-like-this-symbol)
 
 (provide 'init-multiple-cursors)


### PR DESCRIPTION
I _think_ this is the generally useful one.