### PR TITLE
nix: remove gdb

### DIFF
--- a/nix/nixpkgs/config.nix
+++ b/nix/nixpkgs/config.nix
@@ -187,7 +187,6 @@
         cloc
         cmake
         ctags
-        gdb
         git
         graphviz
         hledger


### PR DESCRIPTION
not available on apple arm. See: https://stackoverflow.com/questions/67310123/how-to-install-gdb-on-mac-m1-apple-silicon