### PR TITLE
emacs: mu4e: disable modeline support

### DIFF
--- a/emacs.d/lisp/init-mu4e.el
+++ b/emacs.d/lisp/init-mu4e.el
@@ -15,6 +15,8 @@
   (locate-file "mu4e.el" load-path)
   "Whether mu4e exists on this system")
 
+(setq mu4e-modeline-support nil)
+
 (if mjhoy/mu4e-exists-p
     (progn
       ;; mu4e exists on this system


### PR DESCRIPTION
This hides the global email status in the modeline.