### PR TITLE
emacs: eglot: hide inlay hints

### DIFF
--- a/emacs.d/init.el
+++ b/emacs.d/init.el
@@ -74,6 +74,7 @@
 (require 'init-ivy)
 (require 'init-magit)
 (require 'init-treemacs)
+(require 'init-eglot)
 (require 'init-scheme)
 (require 'init-ruby)
 (require 'init-python)

--- a/emacs.d/lisp/init-eglot.el
+++ b/emacs.d/lisp/init-eglot.el
@@ -1,0 +1,6 @@
+(require 'eglot)
+
+(add-to-list 'eglot-ignored-server-capabilities
+             :inlayHintProvider)
+
+(provide 'init-eglot)


### PR DESCRIPTION
These are mostly just annoying.