### PR TITLE
emacs: ruby: turn off eglot

### DIFF
--- a/emacs.d/lisp/init-ruby.el
+++ b/emacs.d/lisp/init-ruby.el
@@ -15,7 +15,6 @@
 (defun mjhoy/setup-ruby-mode ()
   "My setup for ruby-mode."
   (yard-mode)
-  (eglot-ensure)
   )
 
 (defun mjhoy/setup-inf-ruby-mode ()


### PR DESCRIPTION
Not using Ruby too much these days so don't want to set this up (yet).