### PR TITLE
emacs: config for the fancy treesitter typescript stuffs

### DIFF
--- a/emacs.d/init.el
+++ b/emacs.d/init.el
@@ -50,6 +50,7 @@
 (require 'init-diminish)
 (require 'init-ui)
 (require 'init-theme)
+(require 'init-treesitter)
 (require 'init-hl-line)
 (require 'init-multiple-cursors)
 (require 'init-prog)

--- a/emacs.d/lisp/init-treesitter.el
+++ b/emacs.d/lisp/init-treesitter.el
@@ -1,0 +1,11 @@
+;; TODO: I haven't yet figured out how to manage treesitter grammars
+;; with nix yet, so for now I'm just compiling manually. This is
+;; actually pretty easy with the "casouri/tree-sitter-module" script
+;; linked here:
+;; https://git.savannah.gnu.org/cgit/emacs.git/tree/admin/notes/tree-sitter/starter-guide?h=feature/tree-sitter
+;;
+;; I cloned the repo in ~/src and ran the `batch.sh` script.
+(if (file-directory-p (expand-file-name "~/src/tree-sitter-module/dist"))
+    (add-to-list 'treesit-extra-load-path (expand-file-name "~/src/tree-sitter-module/dist")))
+
+(provide 'init-treesitter)

--- a/emacs.d/lisp/init-typescript.el
+++ b/emacs.d/lisp/init-typescript.el
@@ -5,9 +5,16 @@
 (add-to-list 'eglot-server-programs
              '((typescript-mode) "typescript-language-server" "--stdio"))
 
-(add-to-list 'auto-mode-alist '("\\.ts\\'" .  web-mode))
+(add-to-list 'auto-mode-alist '("\\.ts\\'" .  tsx-ts-mode))
 
-(add-to-list 'auto-mode-alist '("\\.tsx\\'" . web-mode))
+(add-to-list 'auto-mode-alist '("\\.tsx\\'" . tsx-ts-mode))
+
+(defun mjhoy/setup-tsx-ts-mode ()
+  "My setup for tsx-ts-mode."
+  (eglot-ensure)
+  )
+
+(add-hook 'tsx-ts-mode-hook 'mjhoy/setup-tsx-ts-mode)
 
 ;; enable typescript-tslint checker
 (flycheck-add-mode 'typescript-tslint 'web-mode)

--- a/nix/nixpkgs/config.nix
+++ b/nix/nixpkgs/config.nix
@@ -138,6 +138,7 @@
           haskell-mode
           ibuffer-vc
           js2-mode
+          jtsx
           markdown-mode
           material-theme
           multiple-cursors


### PR DESCRIPTION
`tsx-ts-mode` uses treesitter. I haven't quite figured out how to get those
built in my nix environment yet, so for now I'm just pointing at a directory
that contains the built grammars.