### PR TITLE
emacs: add ".project" to project-vc-extra-root-markers

### DIFF
--- a/emacs.d/lisp/init-project.el
+++ b/emacs.d/lisp/init-project.el
@@ -3,6 +3,8 @@
 (global-set-key (kbd "C-c p p") 'project-switch-project)
 (global-set-key (kbd "C-c p &") 'project-async-shell-command)
 
+(setq project-vc-extra-root-markers '(".project"))
+
 (define-key project-prefix-map "m" #'magit-project-status)
 (add-to-list 'project-switch-commands '(magit-project-status "Magit") t)
 


### PR DESCRIPTION
lets me add `.project` files to indicate sub-projects within a git repo. this
lets eglot work correctly in certain circumstances.