### PR TITLE
emacs: scala: remove organize imports hook for now

### DIFF
--- a/emacs.d/lisp/init-scala.el
+++ b/emacs.d/lisp/init-scala.el
@@ -12,7 +12,7 @@
   "My setup for scala-ts-mode."
   (eglot-ensure)
   (add-hook 'before-save-hook #'eglot-format-buffer nil t)
-  (add-hook 'before-save-hook #'mjhoy/eglot-organize-imports 5 t)
+  ;; (add-hook 'before-save-hook #'mjhoy/eglot-organize-imports 5 t)
   )
 
 (add-hook 'scala-ts-mode-hook 'mjhoy/setup-scala-ts-mode)


### PR DESCRIPTION
this has been blowing metals up occassionally and is annoying.