### PR TITLE
devenv: add texinfo

### DIFF
--- a/nix/nixpkgs/config.nix
+++ b/nix/nixpkgs/config.nix
@@ -228,6 +228,7 @@
         protobuf
         ripgrep
         silver-searcher
+        texinfo
         tmux
         tree
         watch


### PR DESCRIPTION
This is needed for running `makeinfo` after building elisp packages.