### PR TITLE
emacs: org: switch agenda 'tasks' section to 'next'

### DIFF
--- a/emacs.d/lisp/init-org/agenda.el
+++ b/emacs.d/lisp/init-org/agenda.el
@@ -40,11 +40,11 @@
                   ((org-agenda-skip-function
                     '(org-agenda-skip-entry-if 'deadline))
                    (org-deadline-warning-days 0)))
-          (todo "TODO|NEXT|REVIEW|DEPLOY|WAIT|HOLD"
+          (todo "NEXT|REVIEW|DEPLOY"
                 ((org-agenda-skip-function
                   '(org-agenda-skip-entry-if 'deadline 'scheduled))
                  (org-agenda-prefix-format "  %i %-12:c [%e] ")
-                 (org-agenda-overriding-header "\nTasks\n")))
+                 (org-agenda-overriding-header "\nNext\n")))
           (agenda nil
                   ((org-agenda-entry-types '(:deadline))
                    (org-agenda-format-date "")


### PR DESCRIPTION
instead of listing *all* my todos in the agenda, just list "next", so i can
actually go and pick what shows up on my agenda for the day to some extend.