### PR TITLE
zsh: init PATH in zprofile

### DIFF
--- a/scripts/install-dotfiles.sh
+++ b/scripts/install-dotfiles.sh
@@ -24,6 +24,7 @@ dotfiles=( gemrc
            offlineimaprc
            offlineimap.py
            eslintrc
+           zprofile
            zshrc
          )
 regex="/?([^/]+)$"

--- a/zprofile
+++ b/zprofile
@@ -1,0 +1,23 @@
+# -*- mode: sh -*-
+
+# Environment shared by interactive and non-interactive login shells.
+typeset -U PATH path # path entries are unique
+path=(
+  "$HOME/.nix-profile/bin"
+  "$HOME/.local/bin"
+  "$HOME/.docker/bin"
+  "$HOME/.cargo/bin"
+  "$HOME/.cabal/bin"
+  "$HOME/.ghcup/bin"
+  "$HOME/.rbenv/shims"
+  "$HOME/.rbenv/bin"
+  "$HOME/.yarn/bin"
+  "$HOME/bin"
+  "$HOME/Library/Application Support/Coursier/bin"
+  "/opt/homebrew/bin"
+  "/usr/local/bin"
+  "/usr/local/sbin"
+  "/usr/local/mysql/bin"
+  "$path[@]"
+)
+export PATH

--- a/zshrc
+++ b/zshrc
@@ -1,26 +1,7 @@
 # -*- mode: sh -*-
 
-# path setup
-typeset -U PATH path # path entries are unique
-path=(
-  "$HOME/.nix-profile/bin"
-  "$HOME/.local/bin"
-  "$HOME/.docker/bin"
-  "$HOME/.cargo/bin"
-  "$HOME/.cabal/bin"
-  "$HOME/.ghcup/bin"
-  "$HOME/.rbenv/shims"
-  "$HOME/.rbenv/bin"
-  "$HOME/.yarn/bin"
-  "$HOME/bin"
-  "$HOME/Library/Application Support/Coursier/bin"
-  "/opt/homebrew/bin"
-  "/usr/local/bin"
-  "/usr/local/sbin"
-  "/usr/local/mysql/bin"
-  "$path[@]"
-)
-export PATH
+# Load the environment used by login shells.
+source ~/.zprofile
 
 # ssh agent
 SSH_ENV="$HOME/.ssh/environment"


### PR DESCRIPTION
This makes e.g. nix available in non-interactive shells, such as the one that
Codex uses.