### PR TITLE
ci: fix update action

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -20,7 +20,7 @@ jobs:
         name: mjhoy
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
         extraPullNames: nix-community
-    - run: nix build .#devEnv
+    - run: nix build --no-link .#devEnv
     - run: |
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
The `nix build` step was creating a symlink in the directory which later caused
the flake command to fail (it requires a clean git tree).